### PR TITLE
convert to streams and handle phantom ourselves

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -1,0 +1,42 @@
+'use strict';
+var webpage = require('webpage');
+var page = webpage.create();
+var options = JSON.parse(phantom.args[0]);
+
+var log = console.log;
+// make sure phantom never outputs to stdout
+console.log = console.error;
+
+phantom.onError = function(msg, trace) {
+	var msgStack = ['PHANTOM ERROR: ' + msg];
+
+	if (trace && trace.length) {
+		msgStack.push('TRACE:');
+		trace.forEach(function(t) {
+			msgStack.push(' -> ' + (t.file || t.sourceURL) + ': ' + t.line + (t.function ? ' (in function ' + t.function +')' : ''));
+		});
+	}
+
+	console.error(msgStack.join('\n'));
+};
+
+page.onError = function (err) {
+	console.error(err);
+};
+
+page.open(options.url, function (status) {
+	if (status === 'fail') {
+		console.error('Couldn\'t load url');
+		phantom.exit(1);
+	}
+
+	page.viewportSize = {
+		width: options.width,
+		height: options.height
+	};
+
+	window.setTimeout(function () {
+		log.call(console, page.renderBase64('png'));
+		phantom.exit(0);
+	}, options.renderDelay);
+});

--- a/package.json
+++ b/package.json
@@ -39,11 +39,12 @@
     "each-async": "~0.1.2",
     "chalk": "~0.4.0",
     "nopt": "~2.1.2",
-    "webshot": "~0.10.0",
     "slugify-url": "~1.0.1",
     "sudo-block": "~0.3.0",
     "lodash": "~2.4.1",
-    "get-stdin": "~0.1.0"
+    "get-stdin": "~0.1.0",
+    "phantomjs": "~1.9.7-1",
+    "base64-stream": "~0.1.2"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Fixes #1

The API now returns an array of streams. The obvious benefit is that everything is operated in memory and will never exhaust the memory. I chose to drop the webshot dependency as it was easier to use phantom directly.

@kevva mind reviewing? what do you think of the API?
