### PR TITLE
Fix test log

### DIFF
--- a/test.js
+++ b/test.js
@@ -4,17 +4,19 @@ var assert = require('assert');
 var fs = require('fs');
 var pageres = require('./index');
 
-it('should generate screenshots', function (cb) {
-	this.timeout(20000);
+describe('pageres', function () {
+	it('should generate screenshots', function (cb) {
+		this.timeout(20000);
 
-	pageres(['yeoman.io', 'todomvc.com'], ['1024x768', '640x480'], function (err, streams) {
-		assert(!err);
-		assert.strictEqual(streams.length, 4);
-		assert.strictEqual(streams[0].filename, 'yeoman.io-1024x768.png');
+		pageres(['yeoman.io', 'todomvc.com'], ['1024x768', '640x480'], function (err, streams) {
+			assert(!err);
+			assert.strictEqual(streams.length, 4);
+			assert.strictEqual(streams[0].filename, 'yeoman.io-1024x768.png');
 
-		streams[0].once('data', function (data) {
-			assert(data.length > 1000);
-			cb();
+			streams[0].once('data', function (data) {
+				assert(data.length > 1000);
+				cb();
+			});
 		});
 	});
 });


### PR DESCRIPTION
If there is an error output will just be _should .._' and that looks very weird. With addition of `describe()` there will be _pageres should ..._ — correct log.
