### PR TITLE
Added ability to specify cookies

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -50,10 +50,10 @@ function init(args) {
 			}
 		}
 	}
-	
+
 	var urls = _.uniq(args.filter(/./.test, /\./));
 	var sizes = _.uniq(args.filter(/./.test, /^\d{3,4}x\d{3,4}$/i));
-	
+
 	var cookieJSON = [],
 	    commonNames = ['domain', 'path', 'httponly', 'secure', 'expires'];
 
@@ -97,7 +97,7 @@ function init(args) {
 		sizes = defRes.split(' ');
 	}
 
-	pageres(urls, sizes, cookieJSON, function (err, items) {
+	pageres(urls, sizes, function (err, items) {
 		if (err) {
 			throw err;
 		}
@@ -115,7 +115,7 @@ function init(args) {
 			var u = urls.length;
 			var s = sizes.length;
 
-			console.log(chalk.green('\n? Successfully generated %d screenshots from %d %s and %d %s'), u * s, u, (u === 1 ? 'url' : 'urls'), s, (s === 1 ? 'resolution': 'resolutions'));
+			console.log(chalk.green('\n✓ Successfully generated %d screenshots from %d %s and %d %s'), u * s, u, (u === 1 ? 'url' : 'urls'), s, (s === 1 ? 'resolution': 'resolutions'));
 		});
 	});
 }

--- a/converter.js
+++ b/converter.js
@@ -41,8 +41,12 @@ page.open(options.url, function (status) {
 		height: options.height
 	};
 
+	page.evaluate(function () {
+		document.body.style.background = 'white';
+	});
+
 	window.setTimeout(function () {
 		log.call(console, page.renderBase64('png'));
 		phantom.exit(0);
-	}, options.renderDelay);
+	}, options.delay * 1000);
 });

--- a/cookies.json
+++ b/cookies.json
@@ -1,9 +1,0 @@
-{
-	"cookies": [
-		{
-			"name": "Cookie Name",
-			"value": "Cookie Value",
-			"domain": "domain.com"
-		}
-	]
-}

--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 'use strict';
 var spawn = require('child_process').spawn;
 var path = require('path');
-var fs = require('fs');
+var _ = require('lodash');
 var urlMod = require('url');
 var slugifyUrl = require('slugify-url');
 var phantomjsBin = require('phantomjs').path;
 var base64 = require('base64-stream');
+var assign = require('object-assign');
 
 function runPhantomjs(options) {
 	var cp = spawn(phantomjsBin, [
@@ -16,6 +17,14 @@ function runPhantomjs(options) {
 	var stream = cp.stdout.pipe(base64.decode());
 
 	process.stderr.setMaxListeners(0);
+
+	cp.stdout.on('data', function (data) {
+		// stupid phantomjs outputs this on stdout...
+		if (/Couldn\'t load url/.test(data)) {
+			return stream.emit('error', new Error('Couldn\'t load url'));
+		}
+	});
+
 	cp.stderr.on('data', function (data) {
 		// ignore phantomjs noise
 		if (/ phantomjs\[/.test(data)) {
@@ -28,42 +37,65 @@ function runPhantomjs(options) {
 	return stream;
 }
 
-function generateSizes(url, size, cookies) {
+function generateSizes(url, size, opts, cookies) {
+	url = url.replace(/^localhost/, 'http://$&');
 	url = urlMod.parse(url).protocol ? url : 'http://' + url;
-	// strip `www.` and convert to valid filename
+
+	// strip `www.`
 	url = url.replace(/^(?:https?:\/\/)?www\./, '');
 
+	// make it a valid filename
 	var filenameUrl = slugifyUrl(url);
+
 	var filename = filenameUrl + '-' + size + '.png';
 	var dim = size.split(/x/i);
-	var options = {
-		url: url.toLowerCase(),
+
+	var defaults = {
+		delay: 0
+	};
+
+	var stream = runPhantomjs([defaults, opts, {
+		url: url,
 		width: dim[0],
 		height: dim[0],
 		cookies: cookies
-	};
+	}].reduce(assign));
 
-	var stream = runPhantomjs(options);
 	stream.filename = filename;
+
 	return stream;
 }
 
-module.exports = function (urls, sizes, cookies, cb) {
-	cb = cb || function () {};
-	
-	if (urls.length === 0) {
-		return cb(new Error('`urls` required'));
-	}
-
-	if (sizes.length === 0) {
-		return cb(new Error('`sizes` required'));
-	}
-
+module.exports = function (args, opts, cookies, cb) {
 	var items = [];
 
-	urls.forEach(function (url) {
-		sizes.forEach(function (size) {
-			items.push(generateSizes(url, size, cookies));
+	if (!cb && _.isFunction(opts)) {
+		cb = opts;
+		opts = {};
+	}
+
+	args = args || [];
+	opts = opts || {};
+	cb = cb || function () {};
+
+	if (!phantomjsBin) {
+		return cb('The automatic install of PhantomJS, which is used for generating the screenshots, seems to have failed.\nTry installing it manually: http://phantomjs.org/download.html');
+	}
+
+	args.forEach(function (arg) {
+		if (!arg.url || arg.url.length === 0) {
+			return cb(new Error('URLs required'));
+		}
+
+		if (!arg.sizes || arg.sizes.length === 0) {
+			return cb(new Error('Sizes required'));
+		}
+
+		arg.url = Array.isArray(arg.url) ? arg.url.join('') : arg.url;
+		arg.sizes = Array.isArray(arg.sizes) ? arg.sizes : [arg.sizes];
+
+		arg.sizes.forEach(function (size) {
+			items.push(generateSizes(arg.url, size, opts, cookies));
 		});
 	});
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Get screenshots of the websites in different resolutions
 
-[![Build Status](https://travis-ci.org/sindresorhus/pageres.png?branch=master)](https://travis-ci.org/sindresorhus/pageres)
+[![Build Status](https://travis-ci.org/sindresorhus/pageres.svg?branch=master)](https://travis-ci.org/sindresorhus/pageres)
 
 A good way to make sure your websites are responsive.
 
@@ -13,9 +13,7 @@ It's speedy and generates 100 screenshots from 10 different websites in just ove
 ![](screenshot-output.png)
 
 
-## CLI app
-
-### Install
+## Install
 
 ```sh
 $ npm install --global pageres
@@ -24,27 +22,70 @@ $ npm install --global pageres
 *PhantomJS, which is used for generating the screenshots, is installed automagically, but in some [rare cases](https://github.com/Obvious/phantomjs/issues/102) it might fail to and you'll get an `Error: spawn EACCES` error. [Download](http://phantomjs.org/download.html) PhantomJS manually and reinstall pageres if that happens.*
 
 
-### Usage
+## Usage
 
-```sh
+```
 $ pageres --help
 
-Get screenshots of websites in different resolutions.
-
-Specify urls and screen resolutions as arguments. Order doesn't matter.
+Specify urls and screen resolutions as arguments. Order doesn't matter. Group arguments with [ ]
+Screenshots are saved in the current directory.
 
 Usage
-  pageres <url> <resolution> [<resolution> <url> ...]
-  pageres [<url> <resolution> ...] < <file>
-  cat <file> | pageres [<url> <resolution> ...]
+  pageres <url> <resolution>
+  pageres [ <url> <resolution> ] [ <url> <resolution> ]
+  pageres [ <url> <resolution> ... ] < <file>
+  cat <file> | pageres [ <url> <resolution> ... ]
 
 Example
   pageres todomvc.com yeoman.io 1366x768 1600x900
-  pageres 1366x768 < urls.txt
+  pageres [ yeoman.io 1366x768 1600x900 ] [ todomvc.com 1024x768 480x320 ]
+  pageres --delay 3 1366x768 < urls.txt
   cat screen-resolutions.txt | pageres todomvc.com yeoman.io
 
-You can also pipe in a newline separated list of urls and screen resolutions which will get merged with the arguments.
-If no screen resolutions are specified it will fall back to the ten most popular ones according to w3counter.
+Options
+  -d, --delay <seconds>    Delay capturing the screenshot
+
+You can also pipe in a newline separated list of urls and screen resolutions which will get merged with the arguments. If no screen resolutions are specified it will fall back to the ten most popular ones according to w3counter.
+```
+
+
+## API
+
+*The API is still in flux and might change between minor versions. Feedback welcome!*
+
+### Install
+
+```sh
+$ npm install --save pageres
+```
+
+### Usage
+
+```js
+var eachAsync = require('each-async');
+var pageres = require('pageres');
+
+var items = [{
+	url: 'yeoman.io',
+	sizes: ['480x320', '1024x768']
+}, {
+	url: 'todomvc.com',
+	sizes: ['1280x1024', '1920x1080']
+}];
+
+pageres(items, { delay: 2 }, function (err, shots) {
+	eachAsync(shots, function (el, i, next) {
+		var stream = el.pipe(fs.createWriteStream(el.filename));
+		stream.on('finish', next);
+		stream.on('error', next);
+	}, function (err) {
+		if (err) {
+			throw err;
+		}
+
+		console.log('done');
+	});
+});
 ```
 
 ### Cookies
@@ -57,24 +98,16 @@ Modify the "cookies.json" file with the cookies you need, then call pageres with
 $ pageres todomvc.com 1920x1080 cookies.json
 ```
 
+### Options
 
-## Programmatic API
+#### delay
 
-### Install
+Type: `number`  
+Default: `0`
 
-```sh
-$ npm install --save pageres
-```
+Delay capturing the screenshot.
 
-### Example
-
-```js
-var pageres = require('pageres');
-
-pageres(['todomvc.com'], ['1366x768', '1600x900'], function () {
-	console.log('done');
-});
-```
+Useful when the site does things after load that you want to capture.
 
 
 ## Google Analytics screen resolutions
@@ -91,4 +124,4 @@ You can use the most popular resolutions for your site with `pageres` by followi
 
 ## License
 
-MIT © [Sindre Sorhus](http://sindresorhus.com)
+MIT Â© [Sindre Sorhus](http://sindresorhus.com)


### PR DESCRIPTION
Using a .JSON file (see cookies.json), you can attach cookies to the
phantom page request. This will allow you to capture pages that are
behind a login wall.

An issue exists for this at: https://github.com/sindresorhus/pageres/issues/41
