### PR TITLE
Allow users to specify keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "slugify-url": "^1.2.0",
     "subarg": "^0.0.1",
     "sudo-block": "^0.4.0",
-    "update-notifier": "^0.1.8"
+    "update-notifier": "^0.1.8",
+    "viewport-list": "^0.1.2"
   },
   "devDependencies": {
     "concat-stream": "^1.4.5",

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ $ npm install --global pageres
 ```
 $ pageres --help
 
-Specify urls and screen resolutions as arguments. Order doesn't matter. Group arguments with [ ]
+Specify urls, screen resolutions and keywords as arguments. Order doesn't matter. Group arguments with [ ]
 Screenshots are saved in the current directory.
 
 Usage
@@ -37,10 +37,10 @@ Usage
   cat <file> | pageres [ <url> <resolution> ... ]
 
 Example
-  pageres todomvc.com yeoman.io 1366x768 1600x900
-  pageres [ yeoman.io 1366x768 1600x900 ] [ todomvc.com 1024x768 480x320 ]
+  pageres todomvc.com yeoman.io 1366x768 1600x900 iphone5
+  pageres [ yeoman.io 1366x768 1600x900 galaxys4 ] [ todomvc.com 1024x768 480x320 iphone5 ]
   pageres --delay 3 1366x768 < urls.txt
-  pageres unicorn.html 1366x768
+  pageres unicorn.html 1366x768 iphone5
   cat screen-resolutions.txt | pageres todomvc.com yeoman.io
 
 Options

--- a/test.js
+++ b/test.js
@@ -19,13 +19,14 @@ it('should generate screenshots', function (cb) {
 		sizes: ['480x320', '1024x768']
 	}, {
 		url: 'todomvc.com',
-		sizes: ['1280x1024', '1920x1080']
+		sizes: ['1280x1024', '1920x1080', 'iphone5']
 	}];
 
 	pageres(items, function (err, streams) {
 		assert(!err, err);
-		assert.strictEqual(streams.length, 4);
+		assert.strictEqual(streams.length, 5);
 		assert.strictEqual(streams[0].filename, 'yeoman.io-480x320.png');
+		assert.strictEqual(streams[4].filename, 'todomvc.com-320x568.png');
 
 		streams[0].once('data', function (data) {
 			assert(data.length > 1000);


### PR DESCRIPTION
This adds the ability to specify a string or an array of keywords like `iphone` or `galaxytab` etc and it will fetch these devices resolutions.

Fixes #13.
