### PR TITLE
Format help text

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -48,9 +48,9 @@ function showHelp() {
 		  cat screen-resolutions.txt | pageres todomvc.com yeoman.io
 
 		Options
-		  -d, --delay <seconds>		Delay capturing the screenshot
-		  -c, --crop				Crop to the set height
-		  --cookie <cookie>			Browser cookie, can be set multiple times
+		  -d, --delay <seconds>  Delay capturing the screenshot
+		  -c, --crop             Crop to the set height
+		  --cookie <cookie>      Browser cookie, can be set multiple times
 
 		<url> can also be a local file path.
 


### PR DESCRIPTION
Replaced tabs with spaces at `showHelp()` to be better readable.
