### PR TITLE
Add support for customizable filenames

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -42,14 +42,16 @@ function showHelp() {
   Example
     pageres todomvc.com yeoman.io 1366x768 1600x900
     pageres [ yeoman.io 1366x768 1600x900 --no-crop ] [ todomvc.com 1024x768 480x320 ] --crop
+    pageres todomvc.com 1024x768 --name '<%= date %> - <%= url %>'
     pageres --delay 3 1366x768 < urls.txt
     pageres unicorn.html 1366x768
     cat screen-resolutions.txt | pageres todomvc.com yeoman.io
 
   Options
-    -d, --delay <seconds>    Delay capturing the screenshot
+    -d, --delay <seconds>    Delay screenshot capture
     -c, --crop               Crop to the set height
     --cookie <cookie>        Browser cookie, can be set multiple times
+    --name <template>        Custom filename
 
   <url> can also be a local file path.
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var urlMod = require('url');
 var spawn = require('child_process').spawn;
 var _ = require('lodash');
 var assign = require('object-assign');
+var date = require('easydate');
 var eachAsync = require('each-async');
 var fileUrl = require('file-url');
 var getRes = require('get-res');
@@ -30,6 +31,7 @@ function Pageres(options) {
 
 	this.options = assign({}, options);
 	this.options.cookies = (this.options.cookies || []).map(parseCookiePhantomjs);
+	this.options.name = this.options.name || '<%= url %>-<%= size %><%= crop =>';
 	this.stats = {};
 
 	this._src = [];
@@ -252,8 +254,12 @@ Pageres.prototype._generate = function (url, size, options) {
 		newUrl = urlMod.parse(newUrl).protocol ? newUrl : 'http://' + newUrl;
 	}
 
-	name = slugifyUrl(isFile ? url : newUrl).replace(/^(?:https?:\/\/)?www\./, '');
-	name = name + '-' + size + (options.crop ? '-cropped' : '') + '.png';
+	name = _.template(options.name + '.png', {
+		url: slugifyUrl(isFile ? url : newUrl).replace(/^(?:https?:\/\/)?www\./, ''),
+		size: size,
+		crop: options.crop ? '-cropped' : '',
+		date: date('Y-M-d')
+	});
 
 	var stream = this._phantom(assign({ delay: 0 }, options, {
 		url: newUrl,

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "chalk": "^0.5.0",
     "each-async": "^1.0.0",
+    "easydate": "^1.0.1",
     "file-url": "^1.0.0",
     "get-res": "^0.2.1",
     "get-stdin": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -32,22 +32,24 @@ Group arguments with [ ]. Options defined inside a group will override the outer
 Screenshots are saved in the current directory.
 
 Usage
-  pageres <url> <resolution>
-  pageres [ <url> <resolution> ] [ <url> <resolution> ]
-  pageres [ <url> <resolution> ... ] < <file>
-  cat <file> | pageres [ <url> <resolution> ... ]
+	pageres <url> <resolution>
+	pageres [ <url> <resolution> ] [ <url> <resolution> ]
+	pageres [ <url> <resolution> ... ] < <file>
+	cat <file> | pageres [ <url> <resolution> ... ]
 
 Example
-  pageres todomvc.com yeoman.io 1366x768 1600x900
-  pageres [ yeoman.io 1366x768 1600x900 --no-crop ] [ todomvc.com 1024x768 480x320 ] --crop
-  pageres --delay 3 1366x768 < urls.txt
-  pageres unicorn.html 1366x768
-  cat screen-resolutions.txt | pageres todomvc.com yeoman.io
+	pageres todomvc.com yeoman.io 1366x768 1600x900
+	pageres [ yeoman.io 1366x768 1600x900 --no-crop ] [ todomvc.com 1024x768 480x320 ] --crop
+	pageres todomvc.com 1024x768 --name '<%= date %> - <%= url %>'
+	pageres --delay 3 1366x768 < urls.txt
+	pageres unicorn.html 1366x768
+	cat screen-resolutions.txt | pageres todomvc.com yeoman.io
 
 Options
-  -d, --delay <seconds>    Delay capturing the screenshot
-  -c, --crop               Crop to the set height
-  --cookie <cookie>        Browser cookie, can be set multiple times
+	-d, --delay <seconds>    Delay screenshot capture
+	-c, --crop               Crop to the set height
+	--cookie <cookie>        Browser cookie, can be set multiple times
+	--name <template>        Custom filename
 
 <url> can also be a local file path.
 
@@ -120,6 +122,20 @@ Same format as a [browser cookie](http://en.wikipedia.org/wiki/HTTP_cookie).
 ###### Tip
 
 Go to the website you want a cookie for and copy-paste it from Dev Tools.
+
+##### name
+
+Type: `string`
+
+Define a customized filename using [Lo-Dash templates](http://lodash.com/docs#template).  
+For example `<%= date %> - <%= url %>-<%= size %><%= crop %>`.
+
+Available variables:
+
+- `url`: The URL in [slugified](https://github.com/ogt/slugify-url) form, eg. `http://yeoman.io/blog/` becomes `yeoman.io!blog`
+- `size`: Specified size, eg. `1024x1000`
+- `crop`: Outputs `-cropped` when the crop option is true
+- `date`: The current date
 
 
 ### pageres.src(url, sizes, options)

--- a/test/test.js
+++ b/test/test.js
@@ -3,9 +3,10 @@ var fs = require('fs');
 var test = require('ava');
 var imageSize = require('image-size');
 var concat = require('concat-stream');
+var date = require('easydate');
+var PNG = require('png-js')
 var Pageres = require('../');
-var Server = require('./serverForCookieTests');
-var PNG = require('png-js');
+var Server = require('./serverForCookieTests');;
 
 process.chdir(__dirname);
 
@@ -73,6 +74,19 @@ test('crop image using the `crop` option', function (t) {
 			t.assert(size.width === 1024);
 			t.assert(size.height === 768);
 		}));
+	});
+});
+
+test('rename image using the `name` option', function (t) {
+	t.plan(3);
+
+	var pageres = new Pageres()
+		.src('http://todomvc.com', ['1024x768'], { name: '<%= date %> - <%= url %>' });
+
+	pageres.run(function (err, streams) {
+		t.assert(!err, err);
+		t.assert(streams.length === 1);
+		t.assert(streams[0].filename === date('Y-M-d') + ' - todomvc.com.png');
 	});
 });
 


### PR DESCRIPTION
Far from perfect at the moment, but it works. Not sure how we're going to deal with the `-` in cropped. If we're setting it in the template there will be a empty `-` at the end of files that aren't cropped.

Fixes #35.
