### PR TITLE
Add support for basic HTTP auth

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -54,6 +54,8 @@ function showHelp() {
     --cookie <cookie>        Browser cookie, can be set multiple times
     --name <template>        Custom filename
     --selector <element>     Capture DOM element
+    --username <username>    Username for HTTP auth
+    --password <password>    Password for HTTP auth
 
   <url> can also be a local file path.
 

--- a/converter.js
+++ b/converter.js
@@ -11,6 +11,10 @@ console.log = console.error = function () {
 	system.stderr.writeLine([].slice.call(arguments).join(' '));
 };
 
+if (options.username && options.password) {
+	page.customHeaders = {'Authorization': 'Basic ' + btoa(options.username + ':' + options.password)};
+}
+
 options.cookies.forEach(function (cookie) {
 	if (!phantom.addCookie(cookie)) {
 		console.error('Couldn\'t add cookie: ', cookie);

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,8 @@ Options
 	--cookie <cookie>        Browser cookie, can be set multiple times
 	--name <template>        Custom filename
 	--selector <element>     Capture DOM element
+	--username <username>    Username for HTTP auth
+	--password <password>    Password for HTTP auth
 
 <url> can also be a local file path.
 
@@ -153,6 +155,18 @@ Available variables:
 Type: `string`
 
 Capture a specific DOM element.
+
+##### username
+
+Type: `string`
+
+Username for authenticating with HTTP auth.
+
+##### password
+
+Type: `string`
+
+Password for authenticating with HTTP auth.
 
 
 ### pageres.src(url, sizes, options)

--- a/test/test.js
+++ b/test/test.js
@@ -194,6 +194,22 @@ test('generate screenshot using the CLI', function (t) {
 		});
 });
 
+test('auth using username and password', function (t) {
+	t.plan(3);
+
+	var pageres = new Pageres({username: 'user', password: 'passwd'})
+		.src('httpbin.org/basic-auth/user/passwd', ['120x120']);
+
+	pageres.run(function (err, streams) {
+		t.assert(!err, err);
+		t.assert(streams.length === 1);
+
+		streams[0].once('data', function (data) {
+			t.assert(data.length);
+		});
+	});
+});
+
 function cookieTest (port, input, t) {
 	t.plan(6);
 	var server = new Server(port);


### PR DESCRIPTION
Due to a bug in PhantomJS we have to use `page.customHeaders` instead of the
settings object. See http://mobiletestingfordummies.tumblr.com/post/87004870957/proxy-authentication-in-phantomjs for reference.

Fixes #99.
