### PR TITLE
Fixed white background problem (again)

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -70,7 +70,8 @@ page.open(options.url, function (status) {
 	}
 
 	page.evaluate(function () {
-		if (!window.getComputedStyle(document.body).getPropertyValue('background-color')) {
+		var background = window.getComputedStyle(document.body).getPropertyValue('background-color');
+		if (!background || background === 'rgba(0, 0, 0, 0)') {
 			document.body.style.backgroundColor = 'white';
 		}
 	});


### PR DESCRIPTION
In regards to #115 and #116:

I'm sorry I messed it up. I hadn't tested my fix properly.

So apparently if the `background-color` style is not set in the CSS the computed value in Phantom/Chrome isn't falsy but `rgba(0, 0, 0, 0)` (transparent). So the check in the `if` statement would never catch it and still leave the background color unset.

This patch now checks for both falsy (never know) and `rgba(0, 0, 0, 0)`.

Here are some popular sites that don't have a background color:

```
linkedin.com
microsoft.com
msn.com
taobao.com
weibo.com
yahoo.co.jp
baidu.com
```

They now get a white background while sites that do have a color remain untouched.
