### PR TITLE
readme bugfix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,8 +150,9 @@ $ pageres [ yeoman.io 1366x768 --no-crop ] todomvc.com 1024x768 --crop
 
 Browser cookie, can be set multiple times.
 
-```
+```sh
 $ pageres yeoman.io 1024x768 --cookie 'foo=bar'
+```
 
 ##### `--username <username>`
 


### PR DESCRIPTION
Add missing backticks after cookie example
