### PR TITLE
Add docs badge to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # ![pageres](media/promo.png)
 
-[![Build Status](http://img.shields.io/travis/sindresorhus/pageres/master.svg?style=flat)](https://travis-ci.org/sindresorhus/pageres?style=flat) ![](http://img.shields.io/badge/unicorn-approved-ff69b4.svg?style=flat)
+[![Build Status](http://img.shields.io/travis/sindresorhus/pageres/master.svg?style=flat)](https://travis-ci.org/sindresorhus/pageres?style=flat) ![](http://img.shields.io/badge/unicorn-approved-ff69b4.svg?style=flat) [![Inline docs](http://inch-ci.org/github/sindresorhus/pageres.svg?branch=master)](http://inch-ci.org/github/sindresorhus/pageres)
 
 Capture screenshots of websites in various resolutions. A good way to make sure your websites are responsive.
 


### PR DESCRIPTION
Hi there,

I want to propose to add this badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/sindresorhus/pageres.svg)](http://inch-ci.org/github/sindresorhus/pageres)

The badge links to [Inch CI](http://inch-ci.org) and shows an evaluation by [InchJS](http://trivelop.de/inchjs), a project that tries to raise the visibility of inline-docs (early adopters include [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [when](https://github.com/cujojs/when)).

The idea is to motivate aspiring Node developers to dive into Open Source projects and read the code.
It's about *engagement*, because, while testing and code coverage are important, inline-docs are the humanly engaging factor in Open Source. This project is about making people less adverse to jumping into the code and see whats happening, because they are not left alone while doing so. I know that, because I put off reading other people's code way too long in my life.

Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/sindresorhus/pageres

What do you think?