### PR TITLE
add coverage reporting using nyc and coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+nyc_output
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ node_js:
   - 'iojs'
   - '0.12'
   - '0.10'
+after_success: npm run coveralls

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "node test/test.js"
+    "test": "node test/test.js",
+    "coverage": "nyc npm test && nyc report",
+    "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },
   "files": [
     "index.js",
@@ -83,7 +85,9 @@
     "ava": "0.0.4",
     "concat-stream": "^1.4.5",
     "cookie": "^0.1.2",
+    "coveralls": "^2.11.2",
     "image-size": "^0.3.3",
+    "nyc": "^2.1.4",
     "png-js": "^0.1.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # ![pageres](media/promo.png)
 
 [![Build Status](https://travis-ci.org/sindresorhus/pageres.svg?branch=master)](https://travis-ci.org/sindresorhus/pageres)
-[![Coverage Status](https://coveralls.io/repos/sindresorhus/chalk/badge.svg?branch=)](https://coveralls.io/r/sindresorhus/chalk?branch=master) [![](http://img.shields.io/badge/unicorn-approved-ff69b4.svg)](https://www.youtube.com/watch?v=9auOCbH5Ns4)
+[![Coverage Status](https://coveralls.io/repos/sindresorhus/pageres/badge.svg?branch=master)](https://coveralls.io/r/sindresorhus/pageres?branch=master) [![](http://img.shields.io/badge/unicorn-approved-ff69b4.svg)](https://www.youtube.com/watch?v=9auOCbH5Ns4)
 
 Capture screenshots of websites in various resolutions. A good way to make sure your websites are responsive.
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # ![pageres](media/promo.png)
 
-[![Build Status](https://travis-ci.org/sindresorhus/pageres.svg?branch=master)](https://travis-ci.org/sindresorhus/pageres) [![](http://img.shields.io/badge/unicorn-approved-ff69b4.svg)](https://www.youtube.com/watch?v=9auOCbH5Ns4)
+[![Build Status](https://travis-ci.org/sindresorhus/pageres.svg?branch=master)](https://travis-ci.org/sindresorhus/pageres)
+[![Coverage Status](https://coveralls.io/repos/sindresorhus/chalk/badge.svg?branch=)](https://coveralls.io/r/sindresorhus/chalk?branch=master) [![](http://img.shields.io/badge/unicorn-approved-ff69b4.svg)](https://www.youtube.com/watch?v=9auOCbH5Ns4)
 
 Capture screenshots of websites in various resolutions. A good way to make sure your websites are responsive.
 


### PR DESCRIPTION
This is a great test of `nyc`, since looking through your tests I notice you use child-processes and istanbul doesn't work off the shelf.

Here's what the coverage report looks like:

```shell
---------------|-----------|-----------|-----------|-----------|
File           |   % Stmts |% Branches |   % Funcs |   % Lines |
---------------|-----------|-----------|-----------|-----------|
   ./          |     84.51 |     63.79 |     86.36 |     84.51 |
      cli.js   |        80 |     46.88 |     85.71 |        80 |
      index.js |     90.32 |     84.62 |      87.5 |     90.32 |
   ./lib/      |        88 |        75 |     94.12 |        88 |
      util.js  |        88 |        75 |     94.12 |        88 |
---------------|-----------|-----------|-----------|-----------|
All files      |     85.71 |     66.22 |     89.74 |     85.71 |
---------------|-----------|-----------|-----------|-----------|
```

remember you can use `npm run coverage -- --reporter=lcov`, to start digging into these reports more thoroughly.

---

* run `npm run coverage` to get a human readable coverage report.
* run `npm run coverage -- --reporter=lcov` to get an HTML report over coverage in the /coverage folder.
* run `npm run coveralls` to report coverage to the [coveralls.io](https://coveralls.io/).
  * you'll need to setup your repo on coveralls.io and grap the `COVERALLS_REPO_TOKEN`.
  * on travis-ci.org, you'll need to set an environment variable with the value of `COVERALLS_REPO_TOKEN `