### PR TITLE
Crash on absolute local path - fixes #206

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -14,6 +14,7 @@ import filenamifyUrl from 'filenamify-url';
 import template from 'lodash.template';
 import pify from 'pify';
 import plur from 'plur';
+import pathExists from 'path-exists';
 
 /**
  * Fetch ten most popular resolutions
@@ -102,6 +103,17 @@ export function create(uri, size, options) {
 	const stream = screenshotStream(protocolify(uri), size, options);
 	const filename = template(`${options.filename}.${options.format}`);
 
+	let url;
+
+	try {
+		url = filenamifyUrl(uri);
+	} catch (err) {
+		if (!pathExists.sync(uri)) {
+			throw err;
+		}
+		url = filenamifyUrl(path.basename(uri));
+	}
+
 	stream.filename = filename({
 		crop: options.crop ? '-cropped' : '',
 		date: easydate('Y-M-d'),
@@ -109,7 +121,7 @@ export function create(uri, size, options) {
 		size,
 		width: sizes[0],
 		height: sizes[1],
-		url: filenamifyUrl(uri)
+		url
 	});
 
 	return stream;

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,7 +14,6 @@ import filenamifyUrl from 'filenamify-url';
 import template from 'lodash.template';
 import pify from 'pify';
 import plur from 'plur';
-import pathExists from 'path-exists';
 
 /**
  * Fetch ten most popular resolutions
@@ -103,15 +102,8 @@ export function create(uri, size, options) {
 	const stream = screenshotStream(protocolify(uri), size, options);
 	const filename = template(`${options.filename}.${options.format}`);
 
-	let url;
-
-	try {
-		url = filenamifyUrl(uri);
-	} catch (err) {
-		if (!pathExists.sync(uri)) {
-			throw err;
-		}
-		url = filenamifyUrl(path.basename(uri));
+	if (path.isAbsolute(uri)) {
+		uri = path.basename(uri);
 	}
 
 	stream.filename = filename({
@@ -121,7 +113,7 @@ export function create(uri, size, options) {
 		size,
 		width: sizes[0],
 		height: sizes[1],
-		url
+		url: filenamifyUrl(uri)
 	});
 
 	return stream;

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "memoize-async": "^1.0.1",
     "mkdirp": "^0.5.0",
     "object-assign": "^3.0.0",
+    "path-exists": "^2.1.0",
     "pify": "^2.3.0",
     "plur": "^2.0.0",
     "protocolify": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "memoize-async": "^1.0.1",
     "mkdirp": "^0.5.0",
     "object-assign": "^3.0.0",
-    "path-exists": "^2.1.0",
     "pify": "^2.3.0",
     "plur": "^2.0.0",
     "protocolify": "^1.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -15,28 +15,19 @@ const fsP = pify(fs);
 
 test('expose a constructor', t => {
 	t.is(typeof Pageres, 'function');
-	t.end();
 });
 
 test('add a source', t => {
 	const pageres = new Pageres().src('yeoman.io', ['1280x1024', '1920x1080']);
 	t.is(pageres._src[0].url, 'yeoman.io');
-	t.end();
 });
 
 test('set destination directory', t => {
 	t.is((new Pageres().dest('tmp'))._dest, 'tmp');
-	t.end();
 });
 
 test('error if no url is specified', async t => {
-	try {
-		await new Pageres().src('', []).run();
-		t.fail();
-	} catch (err) {
-		t.ok(err);
-		t.is(err.message, 'URL required');
-	}
+	await t.throws(new Pageres().src('', []).run(), 'URL required');
 });
 
 test('generate screenshots', async t => {
@@ -121,13 +112,8 @@ test('save image', async t => {
 });
 
 test('remove temporary files on error', async t => {
-	try {
-		await new Pageres().src('this-is-a-error-site.io', ['1024x768']).dest(__dirname).run();
-	} catch (err) {
-		t.ok(err);
-		t.is(err.message, 'Couldn\'t load url: http://this-is-a-error-site.io');
-		t.false(await pathExists('this-is-a-error-site.io.png'));
-	}
+	await t.throws(new Pageres().src('this-is-a-error-site.io', ['1024x768']).dest(__dirname).run(), 'Couldn\'t load url: http://this-is-a-error-site.io');
+	t.false(await pathExists('this-is-a-error-site.io.png'));
 });
 
 test('auth using username and password', async t => {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import test from 'ava';
 import imageSize from 'image-size';
 import easydate from 'easydate';
@@ -94,6 +95,12 @@ test('capture a DOM element using the `selector` option', async t => {
 
 test('support local relative files', async t => {
 	const streams = await new Pageres().src('fixture.html', ['1024x768']).run();
+	t.is(streams[0].filename, 'fixture.html-1024x768.png');
+	t.true((await getStream.buffer(streams[0])).length > 1000);
+});
+
+test('support local absolute files', async t => {
+	const streams = await new Pageres().src(path.join(__dirname, 'fixture.html'), ['1024x768']).run();
 	t.is(streams[0].filename, 'fixture.html-1024x768.png');
 	t.true((await getStream.buffer(streams[0])).length > 1000);
 });


### PR DESCRIPTION
`filenamify-url` throws an error on an absolute local path (actually it's punycode that is used by normalize-url, but still).

This PR fixes that.

-

Fixes #206