### PR TITLE
use local server - fixes #217

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "babel": "^5.8.34",
     "cookie": "^0.2.3",
     "coveralls": "^2.11.2",
+    "get-port": "^2.1.0",
     "get-stream": "^1.0.0",
     "image-size": "^0.4.0",
     "nyc": "^5.0.1",

--- a/test/_server.js
+++ b/test/_server.js
@@ -1,16 +1,37 @@
 'use strict';
+var fs = require('fs');
 var http = require('http');
 var cookie = require('cookie');
+var getPort = require('get-port');
+var pify = require('pify');
+var host = exports.host = 'localhost';
 
-module.exports = function (port) {
-	var server = http.createServer(function (req, res) {
-		var color = cookie.parse(req.headers.cookie).pageresColor || 'white';
+function createServer(fn) {
+	return function () {
+		return getPort().then(function (port) {
+			var server = http.createServer(fn);
 
-		res.writeHead(200, {'content-type': 'text/html'});
-		res.end('<body><div style="background: '+ color + ';position: absolute;top: 0;bottom: 0;left: 0;right: 0;"></div></body');
-	});
+			server.host = host;
+			server.port = port;
+			server.url = 'http://' + host + ':' + port;
+			server.protocol = 'http';
 
-	server.listen(port);
+			server.listen(port);
+			server.close = pify(server.close);
 
-	return server;
-};
+			return server;
+		});
+	};
+}
+
+exports.createServer = createServer(function (req, res) {
+	res.writeHead(200, {'content-type': 'text/html'});
+	res.end(fs.readFileSync('fixture.html', 'utf8'));
+});
+
+exports.createCookieServer = createServer(function (req, res) {
+	var color = cookie.parse(req.headers.cookie).pageresColor || 'white';
+
+	res.writeHead(200, {'content-type': 'text/html'});
+	res.end('<body><div style="background: ' + color + ';position: absolute;top: 0;bottom: 0;left: 0;right: 0;"></div></body');
+});

--- a/test/fixture.html
+++ b/test/fixture.html
@@ -1,1 +1,15 @@
-<h1>unicorns</h1>
+<html>
+<head>
+	<style>
+	#team { padding: 0px; height: 80px; width: 1024px; }
+	</style>
+</head>
+<body>
+	<h1>unicorns</h1>
+
+	<ul id="team">
+		<li>Sindre Sorhus</li>
+		<li>Kevin Mårtensson</li>
+	</ul>
+</body>
+</html>


### PR DESCRIPTION
Using a local server to run the tests to speed up the tests.

- Extended `_server.js` with `createServer` and `createCookieServer`
- Added more html to `fixture.html` in order to test dom element capturing
- Extracted the cookie tests to a separate test file. Looked cleaner to me.

Feel free to provide feedback!

@sindresorhus @kevva 