### PR TITLE
Change regex to support small viewports. For example  50x50

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ export default class Pageres {
 	async run() {
 		await Promise.all(this.src().map(src => {
 			const options = objectAssign({}, this.options, src.options);
-			const sizes = arrayUniq(src.sizes.filter(/./.test, /^\d{3,4}x\d{3,4}$/i));
+			const sizes = arrayUniq(src.sizes.filter(/./.test, /^\d{2,4}x\d{2,4}$/i));
 			const keywords = arrayDiffer(src.sizes, sizes);
 
 			if (!src.url) {


### PR DESCRIPTION
Change regex to support small viewports. For example 50x50. Are there any reasons why the range is from 3 to 4?