### PR TITLE
fix event emitter memory leak by only registering once

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -18,6 +18,8 @@ import plur from 'plur';
 const getResMem = mem(getRes);
 const viewportListMem = mem(viewportList);
 
+let listener;
+
 /**
  * Fetch ten most popular resolutions
  *
@@ -65,7 +67,11 @@ export async function save(streams) {
 		return await Promise.all(files.map(file => pify(rimraf)(file)));
 	}
 
-	process.on('SIGINT', async () => process.exit(await end())); // eslint-disable-line
+	if (!listener) {
+		listener = process.on('SIGINT', async () => {
+			process.exit(await end()); // eslint-disable-line
+		});
+	}
 
 	return await Promise.all(streams.map(stream =>
 		new Promise(async (resolve, reject) => {


### PR DESCRIPTION
This may be a bit of a hack, but it stops the `SIGINT` listener getting registered every `run()`.