### PR TITLE
Use a Node.js 4 Babel preset for transpiling ES2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-async-to-generator": "^6.7.4",
     "babel-plugin-transform-runtime": "^6.7.5",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-es2015-node4": "^2.1.0",
     "cookie": "^0.2.3",
     "coveralls": "^2.11.2",
     "get-port": "^2.1.0",
@@ -109,7 +109,7 @@
       "add-module-exports"
     ],
     "presets": [
-      "es2015"
+      "es2015-node4"
     ],
     "sourceMaps": "inline"
   },


### PR DESCRIPTION
Since we only support Node.js `>=4` we might as well use a Babel preset that only transpiles the code needed for this.