### PR TITLE
Include URL hash fragment in filename

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -207,7 +207,6 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 	create(uri: string, size: string, options: Options) {
 		const sizes = size.split('x');
 		const stream = screenshotStream(protocolify(uri), size, options);
-		let hash = '';
 
 		// Coercing to string here to please Flow
 		// TODO: Should fix the Flow type so this isn't necessary
@@ -217,11 +216,6 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 			uri = path.basename(uri);
 		}
 
-		if (url.parse(uri).hash !== null) {
-			// slugify hash if exists
-			hash = filenamify(url.parse(uri).hash);
-		}
-
 		stream.filename = filename({
 			crop: options.crop ? '-cropped' : '',
 			date: easydate('Y-M-d'),
@@ -229,7 +223,7 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 			size,
 			width: sizes[0],
 			height: sizes[1],
-			url: filenamifyUrl(uri) + hash
+			url: filenamifyUrl(uri) + filenamify(url.parse(uri).hash || '')
 		});
 
 		if (options.incrementalName) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,8 +211,16 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 		// TODO: Should fix the Flow type so this isn't necessary
 		const filename = template(`${String(options.filename)}.${String(options.format)}`);
 
+		let hash = url.parse(uri).hash || '';
+
 		if (path.isAbsolute(uri)) {
 			uri = path.basename(uri);
+		}
+
+		// Strip empty hash fragments
+		// i.e #, #/ and #!/
+		if (hash.match(/^#(!)?(\/)?$/)) {
+			hash = '';
 		}
 
 		stream.filename = filename({
@@ -222,7 +230,7 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 			size,
 			width: sizes[0],
 			height: sizes[1],
-			url: filenamifyUrl(uri) + filenamify(url.parse(uri).hash || '')
+			url: filenamifyUrl(uri) + filenamify(hash)
 		});
 
 		if (options.incrementalName) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 import path from 'path';
 import EventEmitter from 'events';
 import {Readable} from 'stream';
+import url from 'url';
 import arrayUniq from 'array-uniq';
 import arrayDiffer from 'array-differ';
 import easydate from 'easydate';
@@ -14,6 +15,7 @@ import rimraf from 'rimraf';
 import screenshotStream from 'screenshot-stream';
 import viewportList from 'viewport-list';
 import protocolify from 'protocolify';
+import filenamify from 'filenamify';
 import filenamifyUrl from 'filenamify-url';
 import template from 'lodash.template';
 import pify from 'pify';
@@ -26,6 +28,7 @@ type Options = {
 	delay?: number;
 	timeout?: number;
 	crop?: boolean;
+	hash?: boolean;
 	incrementalName?: boolean;
 	css?: string;
 	cookies?: Array<string> | {[key: string]: string};
@@ -78,7 +81,7 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 		super();
 
 		this.options = Object.assign({}, options);
-		this.options.filename = this.options.filename || '<%= url %>-<%= size %><%= crop %>';
+		this.options.filename = this.options.filename || '<%= url %><%= hash %>-<%= size %><%= crop %>';
 		this.options.format = this.options.format || 'png';
 		this.options.incrementalName = this.options.incrementalName || false;
 
@@ -220,7 +223,9 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 			size,
 			width: sizes[0],
 			height: sizes[1],
-			url: filenamifyUrl(uri)
+			url: filenamifyUrl(uri),
+			// hash: options.hash ? filenamify(uri.match(/#(.+?)(\?|\/|$)/).pop().toString()) : ''
+			hash: options.hash ? filenamify(url.parse(uri).hash) : ''
 		});
 
 		if (options.incrementalName) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -224,7 +224,6 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 			width: sizes[0],
 			height: sizes[1],
 			url: filenamifyUrl(uri),
-			// hash: options.hash ? filenamify(uri.match(/#(.+?)(\?|\/|$)/).pop().toString()) : ''
 			hash: options.hash ? filenamify(url.parse(uri).hash) : ''
 		});
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,6 @@ type Options = {
 	delay?: number;
 	timeout?: number;
 	crop?: boolean;
-	hash?: boolean;
 	incrementalName?: boolean;
 	css?: string;
 	cookies?: Array<string> | {[key: string]: string};

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 		super();
 
 		this.options = Object.assign({}, options);
-		this.options.filename = this.options.filename || '<%= url %><%= hash %>-<%= size %><%= crop %>';
+		this.options.filename = this.options.filename || '<%= url %>-<%= size %><%= crop %>';
 		this.options.format = this.options.format || 'png';
 		this.options.incrementalName = this.options.incrementalName || false;
 
@@ -207,6 +207,7 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 	create(uri: string, size: string, options: Options) {
 		const sizes = size.split('x');
 		const stream = screenshotStream(protocolify(uri), size, options);
+		let hash = '';
 
 		// Coercing to string here to please Flow
 		// TODO: Should fix the Flow type so this isn't necessary
@@ -216,6 +217,11 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 			uri = path.basename(uri);
 		}
 
+		if (url.parse(uri).hash !== null) {
+			// slugify hash if exists
+			hash = filenamify(url.parse(uri).hash);
+		}
+
 		stream.filename = filename({
 			crop: options.crop ? '-cropped' : '',
 			date: easydate('Y-M-d'),
@@ -223,8 +229,7 @@ export default class Pageres<DestValue: string> extends EventEmitter {
 			size,
 			width: sizes[0],
 			height: sizes[1],
-			url: filenamifyUrl(uri),
-			hash: options.hash ? filenamify(url.parse(uri).hash) : ''
+			url: filenamifyUrl(uri) + hash
 		});
 
 		if (options.incrementalName) {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "array-uniq": "^1.0.2",
     "babel-runtime": "^6.6.1",
     "easydate": "^2.0.0",
+    "filenamify": "^2.0.0",
     "filenamify-url": "^1.0.0",
     "fs-write-stream-atomic": "^1.0.2",
     "get-res": "^3.0.0",

--- a/readme.md
+++ b/readme.md
@@ -59,15 +59,6 @@ Default: `false`
 
 Crop to the set height.
 
-##### hash
-
-Type: `boolean`<br>
-Default: `false`
-
-Keep the hash fragment in the filename.
-
-Beneficial for single page applications using hash-style routing.
-
 ##### css
 
 Type: `string`
@@ -95,7 +86,7 @@ Go to the website you want a cookie for and copy-paste it from Dev Tools.
 Type: `string`
 
 Define a customized filename using [Lo-Dash templates](https://lodash.com/docs#template).<br>
-For example `<%= date %> - <%= url %><%= hash %>-<%= size %><%= crop %>`.
+For example `<%= date %> - <%= url %>-<%= size %><%= crop %>`.
 
 Available variables:
 
@@ -104,7 +95,6 @@ Available variables:
 - `width`: Width of the specified size, eg. `1024`
 - `height`: Height of the specified size, eg. `1000`
 - `crop`: Outputs `-cropped` when the crop option is true
-- `hash`: Outputs the URL hash fragment in [slugified](https://github.com/sindresorhus/filenamify) form when the hash option is true, e.g. `https://example.com/#/product/listing` becomes `#!product!listing`
 - `date`: The current date (Y-M-d), eg. 2015-05-18
 - `time`: The current time (h-m-s), eg. 21-15-11
 

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Go to the website you want a cookie for and copy-paste it from Dev Tools.
 Type: `string`
 
 Define a customized filename using [Lo-Dash templates](https://lodash.com/docs#template).<br>
-For example `<%= date %> - <%= url %>-<%= size %><%= crop %>`.
+For example `<%= date %> - <%= url %><%= hash %>-<%= size %><%= crop %>`.
 
 Available variables:
 
@@ -104,7 +104,7 @@ Available variables:
 - `width`: Width of the specified size, eg. `1024`
 - `height`: Height of the specified size, eg. `1000`
 - `crop`: Outputs `-cropped` when the crop option is true
-- `hash`: Outputs the URL hash fragment in [slugified](https://github.com/sindresorhus/filenamify) form when the hash option is true, e.g. `https://example.com/#/products` becomes `#!products`
+- `hash`: Outputs the URL hash fragment in [slugified](https://github.com/sindresorhus/filenamify) form when the hash option is true, e.g. `https://example.com/#/product/listing` becomes `#!product!listing`
 - `date`: The current date (Y-M-d), eg. 2015-05-18
 - `time`: The current time (h-m-s), eg. 21-15-11
 

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,15 @@ Default: `false`
 
 Crop to the set height.
 
+##### hash
+
+Type: `boolean`<br>
+Default: `false`
+
+Keep the hash fragment in the filename.
+
+Beneficial for single page applications using hash-style routing.
+
 ##### css
 
 Type: `string`
@@ -90,11 +99,12 @@ For example `<%= date %> - <%= url %>-<%= size %><%= crop %>`.
 
 Available variables:
 
-- `url`: The URL in [slugified](https://github.com/ogt/slugify-url) form, eg. `http://yeoman.io/blog/` becomes `yeoman.io!blog`
+- `url`: The URL in [slugified](https://github.com/sindresorhus/filenamify-url) form, eg. `http://yeoman.io/blog/` becomes `yeoman.io!blog`
 - `size`: Specified size, eg. `1024x1000`
 - `width`: Width of the specified size, eg. `1024`
 - `height`: Height of the specified size, eg. `1000`
 - `crop`: Outputs `-cropped` when the crop option is true
+- `hash`: Outputs the URL hash fragment in [slugified](https://github.com/sindresorhus/filenamify) form when the hash option is true, e.g. `https://example.com/#/products` becomes `#!products`
 - `date`: The current date (Y-M-d), eg. 2015-05-18
 - `time`: The current time (h-m-s), eg. 21-15-11
 

--- a/test/test.js
+++ b/test/test.js
@@ -53,6 +53,30 @@ test('generate screenshots', async t => {
 	t.true((await getStream.buffer(streams[0])).length > 1000);
 });
 
+test('save filename discarding hash', async t => {
+	const streams = await new Pageres()
+		.src('hb.wopian.me/#/', ['480x320'])
+		.run();
+
+	t.is(streams.length, 1);
+	t.is(streams[0].filename, 'hb.wopian.me-480x320.png');
+	t.true((await getStream.buffer(streams[0])).length > 1000);
+});
+
+test('save filename with hash', async t => {
+	const streams = await new Pageres()
+		.src('hb.wopian.me/#/', ['480x320'], {hash: true})
+		.src('hb.wopian.me/#/@wopian', ['480x320'], {hash: true})
+		.src('hb.wopian.me/#/anime/cowboy-bebop', ['480x320'], {hash: true})
+		.run();
+
+	t.is(streams.length, 3);
+	t.is(streams[0].filename, 'hb.wopian.me#-480x320.png');
+	t.is(streams[1].filename, 'hb.wopian.me#!@wopian-480x320.png');
+	t.is(streams[2].filename, 'hb.wopian.me#!anime!cowboy-bebop-480x320.png');
+	t.true((await getStream.buffer(streams[0])).length > 1000);
+});
+
 test('success message', async t => {
 	const stub = sinon.stub(console, 'log');
 	const pageres = new Pageres().src(s.url, ['480x320', '1024x768', 'iphone 5s']);

--- a/test/test.js
+++ b/test/test.js
@@ -59,13 +59,15 @@ test('save filename with hash', async t => {
 		.src('example.com/#/@user', ['480x320'])
 		.src('example.com/#/product/listing', ['480x320'])
 		.src('example.com/#!/bang', ['480x320'])
+		.src('example.com#readme', ['480x320'])
 		.run();
 
-	t.is(streams.length, 4);
+	t.is(streams.length, 5);
 	t.is(streams[0].filename, 'example.com#-480x320.png');
 	t.is(streams[1].filename, 'example.com#!@user-480x320.png');
 	t.is(streams[2].filename, 'example.com#!product!listing-480x320.png');
 	t.is(streams[3].filename, 'example.com#!bang-480x320.png');
+	t.is(streams[4].filename, 'example.com#readme-480x320.png');
 	t.true((await getStream.buffer(streams[0])).length > 1000);
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -53,27 +53,27 @@ test('generate screenshots', async t => {
 	t.true((await getStream.buffer(streams[0])).length > 1000);
 });
 
-test('save filename discarding hash', async t => {
+test('save filename without hash', async t => {
 	const streams = await new Pageres()
-		.src('hb.wopian.me/#/', ['480x320'])
+		.src('example.com/#/product/listing', ['480x320'])
 		.run();
 
 	t.is(streams.length, 1);
-	t.is(streams[0].filename, 'hb.wopian.me-480x320.png');
+	t.is(streams[0].filename, 'example.com-480x320.png');
 	t.true((await getStream.buffer(streams[0])).length > 1000);
 });
 
 test('save filename with hash', async t => {
 	const streams = await new Pageres()
-		.src('hb.wopian.me/#/', ['480x320'], {hash: true})
-		.src('hb.wopian.me/#/@wopian', ['480x320'], {hash: true})
-		.src('hb.wopian.me/#/anime/cowboy-bebop', ['480x320'], {hash: true})
+		.src('example.com/#/', ['480x320'], {hash: true})
+		.src('example.com/#/@user', ['480x320'], {hash: true})
+		.src('example.com/#/product/listing', ['480x320'], {hash: true})
 		.run();
 
 	t.is(streams.length, 3);
-	t.is(streams[0].filename, 'hb.wopian.me#-480x320.png');
-	t.is(streams[1].filename, 'hb.wopian.me#!@wopian-480x320.png');
-	t.is(streams[2].filename, 'hb.wopian.me#!anime!cowboy-bebop-480x320.png');
+	t.is(streams[0].filename, 'example.com#-480x320.png');
+	t.is(streams[1].filename, 'example.com#!@user-480x320.png');
+	t.is(streams[2].filename, 'example.com#!product!listing-480x320.png');
 	t.true((await getStream.buffer(streams[0])).length > 1000);
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -53,27 +53,19 @@ test('generate screenshots', async t => {
 	t.true((await getStream.buffer(streams[0])).length > 1000);
 });
 
-test('save filename without hash', async t => {
-	const streams = await new Pageres()
-		.src('example.com/#/product/listing', ['480x320'])
-		.run();
-
-	t.is(streams.length, 1);
-	t.is(streams[0].filename, 'example.com-480x320.png');
-	t.true((await getStream.buffer(streams[0])).length > 1000);
-});
-
 test('save filename with hash', async t => {
 	const streams = await new Pageres()
-		.src('example.com/#/', ['480x320'], {hash: true})
-		.src('example.com/#/@user', ['480x320'], {hash: true})
-		.src('example.com/#/product/listing', ['480x320'], {hash: true})
+		.src('example.com/#/', ['480x320'])
+		.src('example.com/#/@user', ['480x320'])
+		.src('example.com/#/product/listing', ['480x320'])
+		.src('example.com/#!/bang', ['480x320'])
 		.run();
 
-	t.is(streams.length, 3);
+	t.is(streams.length, 4);
 	t.is(streams[0].filename, 'example.com#-480x320.png');
 	t.is(streams[1].filename, 'example.com#!@user-480x320.png');
 	t.is(streams[2].filename, 'example.com#!product!listing-480x320.png');
+	t.is(streams[3].filename, 'example.com#!bang-480x320.png');
 	t.true((await getStream.buffer(streams[0])).length > 1000);
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -55,6 +55,7 @@ test('generate screenshots', async t => {
 
 test('save filename with hash', async t => {
 	const streams = await new Pageres()
+		.src('example.com#', ['480x320'])
 		.src('example.com/#/', ['480x320'])
 		.src('example.com/#/@user', ['480x320'])
 		.src('example.com/#/product/listing', ['480x320'])
@@ -62,12 +63,13 @@ test('save filename with hash', async t => {
 		.src('example.com#readme', ['480x320'])
 		.run();
 
-	t.is(streams.length, 5);
-	t.is(streams[0].filename, 'example.com#-480x320.png');
-	t.is(streams[1].filename, 'example.com#!@user-480x320.png');
-	t.is(streams[2].filename, 'example.com#!product!listing-480x320.png');
-	t.is(streams[3].filename, 'example.com#!bang-480x320.png');
-	t.is(streams[4].filename, 'example.com#readme-480x320.png');
+	t.is(streams.length, 6);
+	t.is(streams[0].filename, 'example.com-480x320.png');
+	t.is(streams[1].filename, 'example.com-480x320.png');
+	t.is(streams[2].filename, 'example.com#!@user-480x320.png');
+	t.is(streams[3].filename, 'example.com#!product!listing-480x320.png');
+	t.is(streams[4].filename, 'example.com#!bang-480x320.png');
+	t.is(streams[5].filename, 'example.com#readme-480x320.png');
 	t.true((await getStream.buffer(streams[0])).length > 1000);
 });
 


### PR DESCRIPTION
Closes #297 

Uses Node's [URL](https://nodejs.org/api/url.html) to grab the hash and filenameify's the output.

url: `example.com/#/hello`
size: `['480x320']`

filename: `example.com#!hello-480x320`

---

Edit: I initially implemented this with `<%= hash %>` independant of `<%= url %>`, although I feel like it's now better off just being within `<%= url %>`, as it's highly unlikely you'd need it anywhere else in the filename and its inherently part of the URL structure.

Will change to that if you also prefer it.