### PR TITLE
Add `launchOptions` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,6 +172,13 @@ Default: `false`
 
 Emulate preference of dark color scheme.
 
+##### launchOptions
+
+Type: `object`\
+Default: `{}`
+
+Specify launch options to be passed to the underlying library and consequently to `puppeteer.launch()`.
+
 ### pageres.src(url, sizes, options?)
 
 Add a page to screenshot.

--- a/readme.md
+++ b/readme.md
@@ -177,7 +177,7 @@ Emulate preference of dark color scheme.
 Type: `object`\
 Default: `{}`
 
-Specify launch options to be passed to the underlying library and consequently to `puppeteer.launch()`.
+Options passed to [`puppeteer.launch()`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).
 
 ### pageres.src(url, sizes, options?)
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -30,7 +30,6 @@ export interface Options {
 	readonly css?: string;
 	readonly script?: string;
 	readonly cookies?: ReadonlyArray<string | Record<string, string>>;
-	readonly launchOptions?: captureWebsite.Options['launchOptions'];
 	readonly filename?: string;
 	readonly incrementalName?: boolean;
 	readonly selector?: string;
@@ -43,6 +42,7 @@ export interface Options {
 	readonly headers?: Record<string, string>;
 	readonly transparent?: boolean;
 	readonly darkMode?: boolean;
+	readonly launchOptions?: captureWebsite.Options['launchOptions'];
 }
 
 export interface Source {
@@ -265,14 +265,14 @@ export default class Pageres extends EventEmitter {
 			styles: options.css && [options.css],
 			scripts: options.script && [options.script],
 			cookies: options.cookies, // TODO: Support string cookies in capture-website
-			launchOptions: options.launchOptions,
 			element: options.selector,
 			hideElements: options.hide,
 			scaleFactor: options.scale === undefined ? 1 : options.scale,
 			type: options.format === 'jpg' ? 'jpeg' : 'png',
 			userAgent: options.userAgent,
 			headers: options.headers,
-			darkMode: options.darkMode
+			darkMode: options.darkMode,
+			launchOptions: options.launchOptions
 		};
 
 		if (options.username && options.password) {

--- a/source/index.ts
+++ b/source/index.ts
@@ -30,7 +30,7 @@ export interface Options {
 	readonly css?: string;
 	readonly script?: string;
 	readonly cookies?: ReadonlyArray<string | Record<string, string>>;
-	readonly launchOptions?: Record<string, string[]>;
+	readonly launchOptions?: captureWebsite.Options['launchOptions'];
 	readonly filename?: string;
 	readonly incrementalName?: boolean;
 	readonly selector?: string;

--- a/source/index.ts
+++ b/source/index.ts
@@ -30,7 +30,7 @@ export interface Options {
 	readonly css?: string;
 	readonly script?: string;
 	readonly cookies?: ReadonlyArray<string | Record<string, string>>;
-	readonly launchOptions?: {[key: string]: string[]};
+	readonly launchOptions?: Record<string, string[]>;
 	readonly filename?: string;
 	readonly incrementalName?: boolean;
 	readonly selector?: string;
@@ -97,7 +97,7 @@ export default class Pageres extends EventEmitter {
 		this.options.filename = this.options.filename ?? '<%= url %>-<%= size %><%= crop %>';
 		this.options.format = this.options.format ?? 'png';
 		this.options.incrementalName = this.options.incrementalName ?? false;
-		this.options.launchOptions = this.options.launchOptions || {};
+		this.options.launchOptions = this.options.launchOptions ?? {};
 
 		// FIXME
 		this.stats = {} as Stats; // eslint-disable-line @typescript-eslint/consistent-type-assertions

--- a/source/index.ts
+++ b/source/index.ts
@@ -30,6 +30,7 @@ export interface Options {
 	readonly css?: string;
 	readonly script?: string;
 	readonly cookies?: ReadonlyArray<string | Record<string, string>>;
+	readonly launchOptions?: {[key: string]: string[]};
 	readonly filename?: string;
 	readonly incrementalName?: boolean;
 	readonly selector?: string;
@@ -96,6 +97,7 @@ export default class Pageres extends EventEmitter {
 		this.options.filename = this.options.filename ?? '<%= url %>-<%= size %><%= crop %>';
 		this.options.format = this.options.format ?? 'png';
 		this.options.incrementalName = this.options.incrementalName ?? false;
+		this.options.launchOptions = this.options.launchOptions || {};
 
 		// FIXME
 		this.stats = {} as Stats; // eslint-disable-line @typescript-eslint/consistent-type-assertions
@@ -263,6 +265,7 @@ export default class Pageres extends EventEmitter {
 			styles: options.css && [options.css],
 			scripts: options.script && [options.script],
 			cookies: options.cookies, // TODO: Support string cookies in capture-website
+			launchOptions: options.launchOptions,
 			element: options.selector,
 			hideElements: options.hide,
 			scaleFactor: options.scale === undefined ? 1 : options.scale,


### PR DESCRIPTION
Closes #365 .

Users can now specify `launchOptions` in Pageres's constructor. This object should have an `args` property which should be an array of strings representing each argument to be sent to `puppeteer.launch()`.

I would like to add that the need for this enhancement came from a project I am developing for university alongside other students. The deadline is 5th January so if you would be kind enough to let me know anything that I can do to speed up the acceptance process, I would be very grateful.