### PR TITLE
Fix for unprivileged user namespaces

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
+      - name: Disable AppArmor for unprivileged user namespaces
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - run: npm test
       - uses: codecov/codecov-action@v3
         if: matrix.node-version == 16


### PR DESCRIPTION
This PR fixes an issue with tests because the test workflow (`main.yml`) uses `ubuntu-latest` and therefore there's error:

> No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.

The approach is the most simple: disable the feature of AppArmor to be able to run the tests.