### PR TITLE
Remove get-res dependency from repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
 		"date-fns": "^3.6.0",
 		"filenamify": "^6.0.0",
 		"filenamify-url": "^3.1.0",
-		"get-res": "^3.0.0",
 		"lodash.template": "^4.5.0",
 		"log-symbols": "^6.0.0",
 		"make-dir": "^5.0.0",
@@ -79,7 +78,6 @@
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^6.0.0",
 		"@types/cookie": "^0.6.0",
-		"@types/get-res": "^3.0.3",
 		"@types/lodash.template": "^4.5.3",
 		"@types/node": "^20.14.12",
 		"@types/png.js": "^0.2.3",

--- a/source/index.ts
+++ b/source/index.ts
@@ -16,7 +16,6 @@ import {unusedFilename} from 'unused-filename';
 import arrayUniq from 'array-uniq';
 import arrayDiffer from 'array-differ';
 import {format as formatDate} from 'date-fns';
-import getResolutions from 'get-res';
 import logSymbols from 'log-symbols';
 import {makeDirectory} from 'make-dir';
 import viewportList from 'viewport-list';
@@ -234,7 +233,6 @@ Data representing a screenshot. Includes the filename from the template in {@lin
 */
 export type Screenshot = Uint8Array & {filename: string};
 
-const getResolutionsMemoized = pMemoize(getResolutions);
 // @ts-expect-error - TS is not very smart.
 const viewportListMemoized = pMemoize(viewportList);
 
@@ -370,10 +368,6 @@ export default class Pageres extends EventEmitter {
 
 			this.#urls.push(source.url);
 
-			if (sizes.length === 0 && keywords.includes('w3counter')) {
-				return this.#resolution(source.url, options);
-			}
-
 			if (keywords.length > 0) {
 				return this.#viewport({url: source.url, sizes, keywords}, options);
 			}
@@ -430,13 +424,6 @@ export default class Pageres extends EventEmitter {
 		};
 
 		console.log(`\n${logSymbols.success} Generated ${screenshots} ${words.screenshots} from ${urls} ${words.urls} and ${sizes} ${words.sizes}`);
-	}
-
-	async #resolution(url: string, options: Options): Promise<void> {
-		for (const item of await getResolutionsMemoized() as Array<{item: string}>) {
-			this.#sizes.push(item.item);
-			this.#items.push(await this.#create(url, item.item, options));
-		}
 	}
 
 	async #viewport(viewport: Viewport, options: Options): Promise<void> {


### PR DESCRIPTION
Remove the `get-res` dependency from the repository.

* **package.json**
  - Remove the `get-res` dependency from the `dependencies` section.
  - Remove the `@types/get-res` dependency from the `devDependencies` section.

* **source/index.ts**
  - Remove the import statement for `getResolutions` from `get-res`.
  - Remove the `getResolutionsMemoized` function.
  - Remove the `#resolution` method.
  - Update the `#viewport` method to no longer use `getResolutionsMemoized`.

